### PR TITLE
Fix for building on Kernel 6.0.12

### DIFF
--- a/driver/ntv2_device.c
+++ b/driver/ntv2_device.c
@@ -685,9 +685,9 @@ static int ntv2_device_dma_configure(struct ntv2_device *ntv2_dev)
 	pci_set_master(pdev);
 
 	/* set dma mask to 64 bits with fallback to 32 bits*/
-	result = pci_set_dma_mask(pdev, DMA_BIT_MASK(64));
+	result = dma_set_mask(&pdev->dev, DMA_BIT_MASK(64));
 	if (result == 0) {
-		result = pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
+		result = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
 		if (result < 0) {
 			NTV2_MSG_DEVICE_ERROR("%s: set consistent dma mask to 64 bit failed code %d\n",
 								  ntv2_dev->name, result);
@@ -696,13 +696,13 @@ static int ntv2_device_dma_configure(struct ntv2_device *ntv2_dev)
 		NTV2_MSG_DEVICE_INFO("%s: pci dma mask = 64 bit\n", ntv2_dev->name);
 	}
 	else {
-		result = pci_set_dma_mask(pdev, DMA_BIT_MASK(32));
+		result = dma_set_mask(&pdev->dev, DMA_BIT_MASK(32));
 		if (result < 0) {
 			NTV2_MSG_DEVICE_ERROR("%s: set dma mask to 32 bit failed code %d\n",
 								  ntv2_dev->name, result);
 			return result;
 		}
-		result = pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		result = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
 		if (result < 0) {
 			NTV2_MSG_DEVICE_ERROR("%s: set consistent dma mask to 32 bit failed code %d\n",
 								  ntv2_dev->name, result);

--- a/driver/ntv2_device.c
+++ b/driver/ntv2_device.c
@@ -702,7 +702,7 @@ static int ntv2_device_dma_configure(struct ntv2_device *ntv2_dev)
 								  ntv2_dev->name, result);
 			return result;
 		}
-		result = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
+		result = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		if (result < 0) {
 			NTV2_MSG_DEVICE_ERROR("%s: set consistent dma mask to 32 bit failed code %d\n",
 								  ntv2_dev->name, result);

--- a/driver/ntv2_nwldma.c
+++ b/driver/ntv2_nwldma.c
@@ -105,7 +105,7 @@ void ntv2_nwldma_close(struct ntv2_nwldma *ntv2_nwl)
 
 	/* free the descriptor memory */
 	if (ntv2_nwl->descriptor != NULL) {
-		pci_free_consistent(ntv2_nwl->ntv2_dev->pci_dev,
+		dma_free_coherent(&(ntv2_nwl->ntv2_dev->pci_dev)->dev,
 							ntv2_nwl->descriptor_memsize,
 							ntv2_nwl->descriptor,
 							ntv2_nwl->dma_descriptor);
@@ -160,9 +160,10 @@ int ntv2_nwldma_configure(struct ntv2_nwldma *ntv2_nwl, struct ntv2_register *nw
 
 	/* allocate descriptor memory */
 	ntv2_nwl->descriptor_memsize = ntv2_nwl->max_descriptors * sizeof(struct ntv2_nwldma_descriptor);
-	ntv2_nwl->descriptor = pci_alloc_consistent(ntv2_nwl->ntv2_dev->pci_dev,
-												ntv2_nwl->descriptor_memsize,
-												&ntv2_nwl->dma_descriptor);
+	ntv2_nwl->descriptor = dma_alloc_coherent(&(ntv2_nwl->ntv2_dev->pci_dev)->dev,
+							ntv2_nwl->descriptor_memsize,
+							&ntv2_nwl->dma_descriptor,
+							GFP_ATOMIC);
 	if (ntv2_nwl->descriptor == NULL) {
 		NTV2_MSG_DMA_ERROR("%s: *error* descriptor memory allocation failed\n", ntv2_nwl->name);
 		return -ENOMEM;

--- a/driver/ntv2_serial.c
+++ b/driver/ntv2_serial.c
@@ -168,7 +168,7 @@ static void ntv2_uartops_shutdown(struct uart_port *port)
 
 static void ntv2_uartops_set_termios(struct uart_port *port,
 									 struct ktermios *termios,
-									 struct ktermios *old)
+									 const struct ktermios *old)
 {
 	struct ntv2_serial *ntv2_ser = container_of(port, struct ntv2_serial, uart_port);
 	u32 valid = NTV2_FLD_MASK(ntv2_kona_fld_serial_rx_valid);

--- a/driver/ntv2_xlxdma.c
+++ b/driver/ntv2_xlxdma.c
@@ -108,7 +108,7 @@ void ntv2_xlxdma_close(struct ntv2_xlxdma *ntv2_xlx)
 
 	/* free the descriptor memory */
 	if (ntv2_xlx->descriptor != NULL) {
-		pci_free_consistent(ntv2_xlx->ntv2_dev->pci_dev,
+		dma_free_coherent(&(ntv2_xlx->ntv2_dev->pci_dev)->dev,
 							ntv2_xlx->descriptor_memsize,
 							ntv2_xlx->descriptor,
 							ntv2_xlx->dma_descriptor);
@@ -192,9 +192,10 @@ int ntv2_xlxdma_configure(struct ntv2_xlxdma *ntv2_xlx, struct ntv2_register *xl
 
 	/* allocate descriptor memory */
 	ntv2_xlx->descriptor_memsize = ntv2_xlx->max_descriptors * sizeof(struct ntv2_xlxdma_descriptor);
-	ntv2_xlx->descriptor = pci_alloc_consistent(ntv2_xlx->ntv2_dev->pci_dev,
+	ntv2_xlx->descriptor = dma_alloc_coherent(&(ntv2_xlx->ntv2_dev->pci_dev)->dev,
 												ntv2_xlx->descriptor_memsize,
-												&ntv2_xlx->dma_descriptor);
+												&ntv2_xlx->dma_descriptor,
+												GFP_ATOMIC);
 	if (ntv2_xlx->descriptor == NULL) {
 		NTV2_MSG_DMA_ERROR("%s: *error* descriptor memory allocation failed\n", ntv2_xlx->name);
 		return -ENOMEM;


### PR DESCRIPTION
Wanted to run on a newer kernel, needed to change pci to dma. Tested and working with kernel 6.0.12,  KONA HDMI https://www.aja.com/products/kona-hdmi and v4l2-ctl 1.22.1.