### PR TITLE
Rework readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# AJA NTV2 V4L2/ALSA
+![enter image description here](https://www.aja.com/media/images/press/aja/AJA_Logo_small.png)
+# NTV2 V4L2/ALSA Kernel Driver
 
 ## Overview
+This repository contains the V4L2/ALSA driver for use with the AJA's NTV2 Video I/O boards.
 
-This repository contains the AJA NTV2 V4L2/ALSA driver.
-
+The driver has been tested on several Ubuntu versions and Centos 7. 
+### Note
+The v4l2-ntv2 driver is designed to be a standalone driver. It is impossible to use this driver in conjunction with AJA's main ntv2 kernel driver. Attempting to load both the ntv2 driver and the v4l2 driver will result in both drivers unable to load correctly.
 ## Version (tag)
 
     v1.0.0    initial release - video/audio capture
@@ -19,49 +22,63 @@ This repository contains the AJA NTV2 V4L2/ALSA driver.
     v2.0.3    support kernels to 5.6
 	
 ## Requirements
-
-Builds in 3.10.0 <= linux (64 bit) <= 5.6.0 (approximately)
-
-AJA Video IO board support:
+ - Linux Kernel (64 bit)  v3.10.0 to 5.15.0 (approximately)
+ - `make` package for your distribution
+## Supported AJA Products
 - Kona 4
 - Corvid 44
 - Corvid 88
 - Corvid HB-R
 - Kona HDMI
 - Kona 1
-
 ## Building the Driver
-
-The v4l2/alsa driver is located in /driver.  A simple 'make' will build
+The v4l2 / alsa driver is located in `/driver`.  A simple `make` will build
 the driver.  If there are build errors they may be due to v4l2 interface
 changes.  To manage this there are several kernel version #ifdef(s)
 in ntv2_common.h.  The kernel versions are approximate; you may need
 to adjust them for your kernel.
+## Installation
+Installation is fairly straight forward. You will need to pull this repo with git, run one make command, and then use the load script to load the driver into the kernel. Note that this driver will need to be loaded on every reboot. 
 
-The driver has been tested on several Ubuntu versions and Centos 7.  Recent
-updates of Centos 7 require that NTV2_USE_SND_CARD_NEW to be defined in
+	git clone https://github.com/aja-video/ntv2-v4l2.git
+	cd ~/ntv2-v4l2/driver
+	make
+	sudo ./load
+
+
+### Note to Centos 7 users
+Recent updates of Centos 7 require that `NTV2_USE_SND_CARD_NEW` to be defined in
 ntv2_common.h.  Uncomment (remove //) this line near the end of the file:
 
-//#define NTV2_USE_SND_CARD_NEW
+    //#define NTV2_USE_SND_CARD_NEW
 
-If any system with a pre 3.16 kernel crashes when the driver loads this
-may be the solution.
+If any system with a pre 3.16 kernel crashes when the driver loads this may also be the solution.
 
-## Loading the Driver
+## Load / Unload Scrips
+The `load` script modprobe(s) several dependencies before loading the ntv2video.ko driver.  There is also an unload script. Unloading the driver requires exiting any application that has opened the driver including the system audio mixer (pulseaudio).
 
-To load the driver use:	'sudo ./load'.  The script modprobe(s) several
-dependencies before loading the ntv2video.ko driver.  There is also an
-unload script.  Unloading the driver requires exiting any application
-that has opened the driver including the system audio mixer (pulseaudio).
+## Example Use
+List the available input devices with `v4l2-ctl`.
 
-## Running Some Tests
+    v4l2-ctl --list-devices
 
-    qv4l2       /* simple v4l2 capture */
-    cheese      /* can do frame grabs */
-    audacity    /* capture audio */
+You can capture the content off of an SDI input with `ffplay`.
 
-    vlc alsa:// --input-slave v4l2://   /* capture video and audio */
-    ffplay -f v4l2 -i /dev/video0       /* capture video */
+     ffplay -f v4l2 -i /dev/video0 
+Note that you can also replace `ffplay` with `ffmpeg` and some additional options to capture the video to disk.
+
+    ffmpeg -f v4l2 -i /dev/video0 -c:v h264 example.mp4
+
+You can also point VLC to the v4l2 video interface and also the alsa audio interface to capture audio and video.
+
+    vlc alsa:// --input-slave v4l2://
+
+### Honorable mentions 
+ - You can use `qv4l2` to perform simple v4l2 capture. 
+ - `Cheese` is a simple camera application that allows users to capture video or still images. 
+ - `Audacity` can be used in conjunction with the alsa driver to capture audio.
+
+   
 
 ## License
 
@@ -79,3 +96,4 @@ BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
 ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+


### PR DESCRIPTION
Reworked readme to be easier to read. Added installation instructions and example commands for use. Improved overall formatting and added warning at the top about this driver being incompatible with the regular NTV2 driver.